### PR TITLE
convert FIPS code to state names with the help of ChatGPT

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,62 @@
+function fipsToStateName(fipsCode) {
+    const fipsToState = {
+      '01': 'Alabama',
+      '02': 'Alaska',
+      '04': 'Arizona',
+      '05': 'Arkansas',
+      '06': 'California',
+      '08': 'Colorado',
+      '09': 'Connecticut',
+      '10': 'Delaware',
+      '11': 'District of Columbia',
+      '12': 'Florida',
+      '13': 'Georgia',
+      '15': 'Hawaii',
+      '16': 'Idaho',
+      '17': 'Illinois',
+      '18': 'Indiana',
+      '19': 'Iowa',
+      '20': 'Kansas',
+      '21': 'Kentucky',
+      '22': 'Louisiana',
+      '23': 'Maine',
+      '24': 'Maryland',
+      '25': 'Massachusetts',
+      '26': 'Michigan',
+      '27': 'Minnesota',
+      '28': 'Mississippi',
+      '29': 'Missouri',
+      '30': 'Montana',
+      '31': 'Nebraska',
+      '32': 'Nevada',
+      '33': 'New Hampshire',
+      '34': 'New Jersey',
+      '35': 'New Mexico',
+      '36': 'New York',
+      '37': 'North Carolina',
+      '38': 'North Dakota',
+      '39': 'Ohio',
+      '40': 'Oklahoma',
+      '41': 'Oregon',
+      '42': 'Pennsylvania',
+      '44': 'Rhode Island',
+      '45': 'South Carolina',
+      '46': 'South Dakota',
+      '47': 'Tennessee',
+      '48': 'Texas',
+      '49': 'Utah',
+      '50': 'Vermont',
+      '51': 'Virginia',
+      '53': 'Washington',
+      '54': 'West Virginia',
+      '55': 'Wisconsin',
+      '56': 'Wyoming',
+    };
+  
+    return fipsToState[fipsCode] || 'Unknown';
+  }
+  
+  
 // Set the width and height of the map container
 const width = 1000;
 const height = 600;
@@ -44,7 +103,7 @@ d3.json("https://d3js.org/us-10m.v1.json").then(function (us) {
             .style("fill", function (d) {
 
                 // Here's where everything went wrong and the state names come out as "undefined"
-                const stateName = d.properties.name;
+                const stateName = fipsToStateName(d.id);
                 const numberOfRailTrails = railTrailsData[stateName] || 0;
                 // Tried to find what the state names look like in GeoJSON but failed
                 console.log('GeoJSON Properties:', d.properties);


### PR DESCRIPTION
Hi! I figured out the issue. The GeoJSON doesn't have state names. It uses FIPS codes (you'll see something called "id" in the GeoJSON, that's each state's two-digit FIPS code). 

Here's my convo with ChatGPT
https://chat.openai.com/share/e82d6d12-82e4-4bd4-b8fd-b01522af0c39

Then I googled "d3 fips code to state name" to make sure ChatGPT isn't messing up the state code numbers. Double checked those against the FCC website here https://transition.fcc.gov/oet/info/maps/census/fips/fips.txt (lots of govt agencies maintain this list, this just happened to be the first google result) 

And voila! 

<img width="851" alt="Screenshot 2024-01-07 at 6 52 54 PM" src="https://github.com/code4policy/2024-a4-Transport-and-Walking/assets/468544/dec23170-6744-4477-8128-6ec1e79998d3">

Feel free to Slack me if you have any questions! 